### PR TITLE
Add favorites features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore my db: username
+config/database.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.2.1'
+ruby '>=3.2.1'
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.0.4', '>= 7.0.4.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,12 +130,15 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.14.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.3-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
     pg (1.5.3)
+    pg (1.5.3-x64-mingw-ucrt)
     public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -212,6 +215,8 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2023.3)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.4.2)
     web-console (4.2.0)
       actionview (>= 6.0.0)
@@ -232,6 +237,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -4,25 +4,23 @@
 
 # 📗 Table of Contents
 
-- [📖 About the Project](#about-project)
-  - [🛠 Built With](#built-with)
-    - [Tech Stack](#tech-stack)
-    - [Key Features](#key-features)
-  - [🚀 Live Demo](#live-demo)
-- [💻 Getting Started](#getting-started)
-  - [Setup](#setup)
-  - [Prerequisites](#prerequisites)
-  - [Install](#install)
-  - [Usage](#usage)
-  - [Run tests](#run-tests)
-  - [Deployment](#triangular_flag_on_post-deployment)
-- [👥 Authors](#authors)
-- [🔭 Future Features](#future-features)
-- [🤝 Contributing](#contributing)
-- [⭐️ Show your support](#support)
-- [🙏 Acknowledgements](#acknowledgements)
-- [❓ FAQ](#faq)
-- [📝 License](#license)
+- [📗 Table of Contents](#-table-of-contents)
+- [📖 Rent a house API ](#-rent-a-house-api-)
+  - [🛠 Built With ](#-built-with-)
+    - [Tech Stack ](#tech-stack-)
+    - [Key Features ](#key-features-)
+    - [Front End app ](#front-end-app-)
+  - [💻 Getting Started ](#-getting-started-)
+    - [Prerequisites](#prerequisites)
+    - [Setup](#setup)
+    - [Install](#install)
+    - [Usage](#usage)
+  - [👥 Authors ](#-authors-)
+  - [🔭 Future Features ](#-future-features-)
+  - [🤝 Contributing ](#-contributing-)
+  - [⭐️ Show your support ](#️-show-your-support-)
+  - [🙏 Acknowledgments ](#-acknowledgments-)
+  - [📝 License ](#-license-)
 
 <!-- PROJECT DESCRIPTION -->
 
@@ -119,10 +117,15 @@ RAILS_DATABASE_PASSWORD=
 
 👤 **Ssekweyama Pius**
 
-
 - GitHub: [@githubhandle](https://github.com/SSEKPIUS)
 - Twitter: [@twitterhandle](https://twitter.com/SSEK_PIUS)
 - LinkedIn: [LinkedIn](https://linkedin.com/in/pius-ssekweyama-23665794)
+
+👤 **Dicko Allasane**
+
+- GitHub: [@Trast00](https://github.com/Trast00)
+- Twitter: [@dickoallassane](https://twitter.com/AllassaneDicko0/)
+- LinkedIn: [@dickoallassane](https://www.linkedin.com/in/allassane-dicko-744aaa224)
 
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/app/controllers/api/v1/favorite_houses_controller.rb
+++ b/app/controllers/api/v1/favorite_houses_controller.rb
@@ -4,4 +4,19 @@ class Api::V1::FavoriteHousesController < ApplicationController
     render json: @favorites
   end
 
+  def create
+    favoritehouse = FavoriteHouse.new(favorite_params)
+
+    if favoritehouse.save
+      render json: favoritehouse, status: :created
+    else
+      render json: { errors: favoritehouse.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def favorite_params
+    params.permit(:user_id, :house_id)
+  end
 end

--- a/app/controllers/api/v1/favorite_houses_controller.rb
+++ b/app/controllers/api/v1/favorite_houses_controller.rb
@@ -6,7 +6,6 @@ class Api::V1::FavoriteHousesController < ApplicationController
   end
 
   def create
-    # ensure add index to ensure uniquness of the pairs (user_id, house_id)
     favoritehouse = FavoriteHouse.new(favorite_params)
 
     if favoritehouse.save

--- a/app/controllers/api/v1/favorite_houses_controller.rb
+++ b/app/controllers/api/v1/favorite_houses_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::FavoriteHousesController < ApplicationController
   def index
     favorites = FavoriteHouse.includes(:house).where(user_id: params[:user_id])
-    house = favorites.map { |favorite| favorite.house}
+    house = favorites.map(&:house)
     render json: house.to_json
   end
 

--- a/app/controllers/api/v1/favorite_houses_controller.rb
+++ b/app/controllers/api/v1/favorite_houses_controller.rb
@@ -14,6 +14,15 @@ class Api::V1::FavoriteHousesController < ApplicationController
     end
   end
 
+  def destroy
+    favorite = FavoriteHouse.find(user_id: params[:user_id], house_id: params[:house_id])
+    if favorite.destroy
+      render json: { deleted_favorite: @favorite, message: 'favorite deleted' }, status: :ok
+    else
+      render json: { error: 'favorite deletion failed' }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def favorite_params

--- a/app/controllers/api/v1/favorite_houses_controller.rb
+++ b/app/controllers/api/v1/favorite_houses_controller.rb
@@ -1,7 +1,8 @@
 class Api::V1::FavoriteHousesController < ApplicationController
   def index
-    @favorites = FavoriteHouse.includes(:house).where(user_id: params[:user_id])
-    render json: @favorites
+    favorites = FavoriteHouse.includes(:house).where(user_id: params[:user_id])
+    house = favorites.map { |favorite| favorite.house}
+    render json: house.to_json
   end
 
   def create

--- a/app/controllers/api/v1/favorite_houses_controller.rb
+++ b/app/controllers/api/v1/favorite_houses_controller.rb
@@ -6,6 +6,7 @@ class Api::V1::FavoriteHousesController < ApplicationController
   end
 
   def create
+    # ensure add index to ensure uniquness of the pairs (user_id, house_id)
     favoritehouse = FavoriteHouse.new(favorite_params)
 
     if favoritehouse.save
@@ -16,7 +17,7 @@ class Api::V1::FavoriteHousesController < ApplicationController
   end
 
   def destroy
-    favorite = FavoriteHouse.find(user_id: params[:user_id], house_id: params[:house_id])
+    favorite = FavoriteHouse.find_by(user_id: params[:user_id], house_id: params[:house_id])
     if favorite.destroy
       render json: { deleted_favorite: @favorite, message: 'favorite deleted' }, status: :ok
     else

--- a/app/controllers/api/v1/favorite_houses_controller.rb
+++ b/app/controllers/api/v1/favorite_houses_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::FavoriteHousesController < ApplicationController
+  def index
+    @favorites = FavoriteHouse.includes(:house).where(user_id: params[:user_id])
+    render json: @favorites
+  end
+
+end

--- a/app/models/favorite_house.rb
+++ b/app/models/favorite_house.rb
@@ -2,4 +2,5 @@ class FavoriteHouse < ApplicationRecord
   belongs_to :user
   belongs_to :house
   validates_presence_of :user_id, :house_id
+  validates :user_id, uniqueness: { scope: :house_id }
 end

--- a/app/models/favorite_house.rb
+++ b/app/models/favorite_house.rb
@@ -1,0 +1,5 @@
+class FavoriteHouse < ApplicationRecord
+  belongs_to :user
+  belongs_to :house
+  validates_presence_of :user_id, :house_id
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :favoritehouses
   has_secure_password
   validates_presence_of :email, :password
   validates_uniqueness_of :email

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,7 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: postgres
 
 development:
   <<: *default

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -3,6 +3,11 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       origins "http://localhost:3000"
       resource "*", headers: :any, methods: [:get, :post, :put, :patch, :delete, :options, :head], credentials: true
     end
+
+    allow do
+      origins "http://localhost:3001"
+      resource "*", headers: :any, methods: [:get, :post, :put, :patch, :delete, :options, :head], credentials: true
+    end
   
     allow do
       origins "https://link-to-production-app.com/"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,10 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1, defaults: { format: :json } do
       resources :houses
-      get '/users/:user_id/favorites', to: 'favorite_houses#index'
+      resources :users, only: [:show] do
+        resources :favorite_houses, only [:index, :create, :destroy]
+      end
+      #get '/users/:user_id/favorites', to: 'favorite_houses#index'
     end
   end
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,8 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1, defaults: { format: :json } do
-      resources :houses 
+      resources :houses
+      get '/users/:user_id/favorites', to: 'favorite_houses#index'
     end
   end
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     namespace :v1, defaults: { format: :json } do
       resources :houses
       resources :users, only: [:show] do
-        resources :favorite_houses, only [:index, :create, :destroy]
+        resources :favorite_houses, only: [:index, :create, :destroy]
       end
       #get '/users/:user_id/favorites', to: 'favorite_houses#index'
     end

--- a/db/migrate/20230510103902_create_favorite_houses.rb
+++ b/db/migrate/20230510103902_create_favorite_houses.rb
@@ -1,0 +1,10 @@
+class CreateFavoriteHouses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :favorite_houses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :house, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230510142903_add_unique_index_to_favorites.rb
+++ b/db/migrate/20230510142903_add_unique_index_to_favorites.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToFavorites < ActiveRecord::Migration[7.0]
+  def change
+    add_index :favorite_houses, [:user_id, :house_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_10_103902) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_10_142903) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_10_103902) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["house_id"], name: "index_favorite_houses_on_house_id"
+    t.index ["user_id", "house_id"], name: "index_favorite_houses_on_user_id_and_house_id", unique: true
     t.index ["user_id"], name: "index_favorite_houses_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_09_153922) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_10_103902) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "favorite_houses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "house_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["house_id"], name: "index_favorite_houses_on_house_id"
+    t.index ["user_id"], name: "index_favorite_houses_on_user_id"
+  end
 
   create_table "houses", force: :cascade do |t|
     t.string "name"
@@ -31,4 +40,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_09_153922) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "favorite_houses", "houses"
+  add_foreign_key "favorite_houses", "users"
 end

--- a/test/fixtures/favorite_houses.yml
+++ b/test/fixtures/favorite_houses.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  house: one
+
+two:
+  user: two
+  house: two

--- a/test/models/favorite_house_test.rb
+++ b/test/models/favorite_house_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class FavoriteHouseTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/models/favorite_house_test.rb
+++ b/test/models/favorite_house_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FavoriteHouseTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
In this pull request, I have been able to:
- Add favorites model and table
- Add favorite controller
  - with the index only
- Add favorites endpoint
  - `/api/v1/users/:user_id/favorite_houses`: for get list of houses
  - `/api/v1/users/:user_id}/favorite_houses/`: for add house
  - `/api/v1/users/:user_id/favorite_houses/house_id/`: for delete house

**Solve [Issue 11](https://github.com/shella12/RentAnItemBackend/issues/11) [issue 14](https://github.com/shella12/RentAnItemBackend/issues/14) [issue 13](https://github.com/shella12/RentAnItemBackend/issues/13)**